### PR TITLE
Set the vertex format in the SphereMaker properly when a vertex color is present

### DIFF
--- a/procedural3d/cone.py
+++ b/procedural3d/cone.py
@@ -768,6 +768,7 @@ class ConeMaker(ModelMaker):
                     vertex_format = GeomVertexFormat.get_v3n3c4t2()
                 else:
                     vertex_format = GeomVertexFormat.get_v3n3c4()
+                vertex_data.set_format(vertex_format)
                 vertex_data = vertex_data.set_color(self._vertex_color)
                 geom.set_vertex_data(vertex_data)
 

--- a/procedural3d/sphere.py
+++ b/procedural3d/sphere.py
@@ -1209,6 +1209,7 @@ class SphereMaker(ModelMaker):
                     vertex_format = GeomVertexFormat.get_v3n3c4t2()
                 else:
                     vertex_format = GeomVertexFormat.get_v3n3c4()
+                vertex_data.set_format(vertex_format)
                 vertex_data = vertex_data.set_color(self._vertex_color)
                 geom.set_vertex_data(vertex_data)
 

--- a/procedural3d/torus.py
+++ b/procedural3d/torus.py
@@ -740,6 +740,7 @@ class TorusMaker(ModelMaker):
                     vertex_format = GeomVertexFormat.get_v3n3c4t2()
                 else:
                     vertex_format = GeomVertexFormat.get_v3n3c4()
+                vertex_data.set_format(vertex_format)
                 vertex_data = vertex_data.set_color(self._vertex_color)
                 geom.set_vertex_data(vertex_data)
 


### PR DESCRIPTION
SphereMaker fails to set the vertex format like, for example, the CylinderMaker when _self._vertex_color_ is not None.  It just needs a missing line added to set the vertex format.